### PR TITLE
Fix for overflow issue

### DIFF
--- a/src/list/list-item.scss
+++ b/src/list/list-item.scss
@@ -5,3 +5,9 @@
 a {
   color: var(--mdc-theme-primary);
 }
+
+
+// override white-space property from @material
+.mdc-list-item__secondary-text {
+  white-space: normal;
+}


### PR DESCRIPTION
On cards where the secondary text of one of the mdc-list-item's is too long, the all layout experiences overflow as can be seen at [Spitsbergen](https://stadnamn.npolar.no/Spitsbergen/Svalbard).

This PR proposes to override the `white-space` property of elements with class name `.mdc-list-item__secondary-text` (defined at @material/mwc-list/src/mwc-list-item.scss) with `normal`.